### PR TITLE
Add a small cheatsheet to language templates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,6 @@
 *.swp
 node_modules
 !.vscode
+
+*/cheatsheet.*
+!boilerplates/cheatsheet.pseudo

--- a/boilerplates/cheatsheet.pseudo
+++ b/boilerplates/cheatsheet.pseudo
@@ -1,0 +1,124 @@
+# This is pseudo code only. Every cheatsheet should follow this structure
+# Comment when you find appropriate.
+# Try to follow language conventions
+
+def main() {
+    ############################################################################
+    # Language idiosyncratics
+    ############################################################################
+    idiosyncratics = """multiline string (or equivalent) with lang specifics
+    * is language strong typed?
+    * indentation matters? What standard (if exists)? <tabs>? <spaces>?
+    * what is the standard naming? camelCaseVariables, snake_case_variables?
+    * other important notes for this language
+    """
+
+
+    ############################################################################
+    # Types
+    ############################################################################
+    t_bool   =  # how booleans are represented?
+    t_str    =  # how strings are represented?
+    t_int    =  # how integers are represented?
+    t_float  =  # how floats are represented?
+    t_struct =  # how to declare and access a structure (or equivalent)
+    t_null   =  # how nulls are represented?
+
+    t_array   =  # how to declare arrays
+    t_hashmap =  # how to declare hashmaps (key: value)
+
+
+    ############################################################################
+    # Maths & Basics
+    ############################################################################
+    t_int++                       # how to increment by one
+    powered      = 2^8            # how to implement power operation
+    mod_division = 13 % 5         # how to mod division (reminder)
+    floored      = 42.8 -> 42     # how to floor()
+    ceiled       = 41.2 -> 42     # how to ceil()
+    rounded      = 2.255 -> 2.56  # how to round with 2 decimal places 
+
+
+    ############################################################################
+    # Functions (probably you must declare the function before main. That's ok)
+    ############################################################################
+    def f_function(int arg1, bool arg2, str arg3="Default") -> (str, bool, int){
+        return (arg3, arg2, arg1)
+    }
+
+    f_function(2, True)             # can omit arguments (defaults)?
+    arg3, arg2, arg1 = f_funcion()  # can return multiple values?
+    values_list = f_function()      # can capture all values on single variable?
+
+
+    ############################################################################
+    # String manipulation
+    ############################################################################
+    c = "concatenate" + " strings"  # if possible,with other types
+    formatted_string = "${var}?"    # how to format strings
+    all_lowercase    =              # convert string to all lowercase
+    all_uppercase    =              # convert string to all uppercase
+    trimmed_string   =              # remove prefix and suffixed spaces
+    split_array      =              # split "a, b, c" into ["a","b","c"]
+    join_array       =              # convert array to string (reverse split)
+    length_of_string =              # count chars (2-byte "ç" should count 1)
+    replaced_string  =              # how to replace on string
+
+    
+    ############################################################################
+    # Conditionals
+    ############################################################################
+    if (conditions) {
+        print("complete <if ifelse else> with examples")
+    } elif (conditions) {
+        print("operators: ==, !=, >, >=, <, <=")
+    } else {
+        printf("string with no newline")
+        printf("\n") # try to show how to print without newline
+    }
+
+
+    ############################################################################
+    # Loops (break/continue apply???)
+    ############################################################################
+    while (1) {                     # show a while loop
+        print("Infinite loops are like this (until break or return)")
+        break
+    }
+
+    for i=0; i<5; i++ {             # show a for loop
+        printf("last printed digit is 4: %d", i)
+    }
+
+    for element in range(t_array) {  # how to iterate a string/array/hashmaps
+        print(f"iterate all elements from an array: {element}")
+    }
+
+
+    ############################################################################
+    # Arrays/Lists/Hashmaps/Dictionary manipulation
+    ############################################################################
+    first_element    = t_array[0]       # does it start on 0? 
+    last_element     = t_array[-1]      # negative index exists?
+    first_and_second = t_array[0:2]     # sub-array syntax? from:to(exclusive?)
+    element_index    = t_array.find(?)  # find index of element? what if absent?
+
+    t_list.append(...)  # how to append elements to array/list
+    popped_string  =    # how to remove/pop elements from array/list
+    length_of_list =    # how to get the length of array/list
+
+    t_hashmap["new_key"] = "new_value"       # insert into hashmaps
+    remove_a_key = t_hashmap.pop("new key")  # remove from hashmaps
+
+    is_true  = "2" in t_list            # check if element exists in array/list
+    is_false = "v" in t_hashmap         # check if key exists in hasmaps
+    is_true  = "v" in t_hashmap.values  # check if value exists in hashmaps
+
+
+    ############################################################################
+    # Regex usage
+    ############################################################################
+    match_list =    # "ab3 c22 dd5"  ->  regex("[a-z]+")  ->  ['ab', 'c', 'dd']
+    is_true =       # how to find if regex matches pattern
+    group_match =   # "<123>abcd</123>"  ->  regex(">([a-z]+)<")  ->  "abc"
+}

--- a/boilerplates/go/cheatsheet.go
+++ b/boilerplates/go/cheatsheet.go
@@ -1,0 +1,186 @@
+package main
+
+import (
+	"fmt"
+	"math"
+	"regexp"
+	"strings"
+	"unicode/utf8"
+)
+
+func fFunction(arg1 int, arg2 bool, arg3 string) (string, bool, int) {
+	return arg3, arg2, arg1
+}
+func fFunction2(arg int) (int, error) {
+	return 0, fmt.Errorf("this is an error message")
+	// return 42, nil
+}
+
+func main() {
+	////////////////////////////////////////////////////////////////////////////
+	// Language idiosyncratics
+	////////////////////////////////////////////////////////////////////////////
+	const idiosyncratics = `
+	- strong typing - variables implicit type with ':=' 
+	- you cannot redeclare variables (:= only the first time)
+	- on variable declaration, Type comes after variableName
+	- indentation should be tabs, not spaces, but no real requirements
+	- all variables MUST be used. Does not compile with unused variables
+	- camelCaseIsRecommended
+`
+
+	////////////////////////////////////////////////////////////////////////////
+	// Types
+	// declare var (explicit type):  var <varName> <type>
+	//                               <varName> = <value>
+	// declare var (explicit type):  var <varName> <type> = <value>
+	// declare var (implicit type):  <varName> := <value> // type depends on <value>
+	////////////////////////////////////////////////////////////////////////////
+	tBool := true     // implicit type declaration with := for booleans
+	tStr := "abc"     // implicit type declaration with := for strings
+	tInt := 123       // implicit type declaration with := for integers
+	tFloat := 1234.56 // or 1.23456e3  // implicit with := for floats
+	type tStruct struct {
+		name  string
+		value int
+	}
+	structVar := tStruct{name: "My Name", value: 42} // access: structVar.name
+	tPointer := &structVar                           // Pointers in Go
+	var tNil *tStruct = nil                          // Null in Go is nil, for objects, maps...
+	// Both tStruct and *tStruct typed variables are accessed with v.name
+
+	tSlice := []int{1, 2, 3, 4} // Arrays and Slices are not the same. For dojo, use slices
+	tMap := map[string]int{     // Maps tMap["key"] = value
+		"hello": 1,
+		"world": 10,
+	} // implicit assignment
+
+	////////////////////////////////////////////////////////////////////////////
+	// Maths & Basics
+	////////////////////////////////////////////////////////////////////////////
+	tInt++                                   // increment by one
+	powered := math.Pow(2, 8)                // 256
+	modDivision := 13 % 5                    // 3
+	floored := math.Floor(42.8)              // 2
+	ceiled := math.Ceil(41.2)                // 2
+	roundedStr := fmt.Sprintf("%.2f", 2.255) // 2.26 - go is dirty for decimal places -.-
+	rounded := math.Round(2.255*100) / 100   // 2.26 - go is dirty for decimal places -.-
+
+	////////////////////////////////////////////////////////////////////////////
+	// Functions (declared outside main)
+	////////////////////////////////////////////////////////////////////////////
+	fFunction(2, true, "string")                 // all arguments are mandatory
+	_, _, newInt := fFunction(2, true, "string") // ignore returned values with _
+
+	// short syntax for error checking: if <call_funcion>; <if clause> { ... }
+	if _, err := fFunction2(0); err != nil {
+		fmt.Println("Handle errors like this:", err)
+	}
+
+	////////////////////////////////////////////////////////////////////////////
+	// String manipulation
+	////////////////////////////////////////////////////////////////////////////
+	c := "concatenate" + " strings" // only strings
+	formattedString := fmt.Sprintf("string: %s, int: %d, float: %.2f, anything?: %v, expanded: %+v, type: %T\n",
+		"string", 42, 123.45, &tStruct{}, structVar, 42.5,
+	)
+	_ = strings.ToUpper("Everything to Uppercase")
+	_ = strings.ToLower("Everything to Lowercase")
+	_ = strings.TrimSpace("  no spaces before or after   \n")
+	splitString := strings.Split("split, a, string", ", ")
+	_ = strings.Join(splitString, ", ")
+	stringLength := utf8.RuneCountInString("ç") // 1
+	stringLengthBytes := len("ç")               // 2 !!! ok when dealing with ascii only
+	_ = strings.ReplaceAll("abc", "bc", "eiou") // abc -> aeiou
+
+	////////////////////////////////////////////////////////////////////////////
+	// Conditionals
+	////////////////////////////////////////////////////////////////////////////
+	if true {
+		fmt.Println("operators: ==, !=, >, >=, <, <=")
+	} else if (tNil == nil || structVar == tStruct{name: "My Name", value: 42}) && "bool" == "only" {
+		fmt.Println("Left conditions are true. Right conditions are False")
+	} else {
+		fmt.Printf("string with no newline")
+		fmt.Println() // empty line
+	}
+
+	////////////////////////////////////////////////////////////////////////////
+	// Loops (break/continue apply)
+	////////////////////////////////////////////////////////////////////////////
+	for {
+		fmt.Println("do infinite loops with a for like this")
+		break
+	}
+
+	for i := 0; i < 5; i++ {
+		fmt.Println("last printed digit is 4:", i)
+	}
+
+	for index, value := range tSlice {
+		fmt.Println("iterate all elements from an slice/array:", index, value)
+	}
+	for key, value := range tMap {
+		fmt.Println("iterate all elements from a Map:", key, value)
+	}
+
+	////////////////////////////////////////////////////////////////////////////
+	// Arrays/Slices/Maps manipulation. Slices in Go are tricky (and performant)
+	// Check https://ueokande.github.io/go-slice-tricks/ for more advanced tips
+	////////////////////////////////////////////////////////////////////////////
+	firstElement := tSlice[0]
+	lastElement := tSlice[len(tSlice)-1]            // no negative index
+	firstAndSecond := tSlice[0:2]                   // sub-slice syntax: from:to(exclusive).
+	firstAndSecond[0] = 55                          // THERE IS NO ALLOCATION, SAME DATA !!!
+	fmt.Println(tSlice[0], "==", firstAndSecond[0]) // THERE IS NO ALLOCATION, SAME DATA !!!
+	elementIndex := -1                              // there is no function for finding elements
+	for i, v := range tSlice {
+		if v == 3 {
+			elementIndex = i
+			break
+		}
+	} // just do it yourself (as everything else in Go)
+	if v, found := tMap["hello"]; found { // finding keys in Maps
+		fmt.Println(v)
+	}
+
+	tSlice = append(tSlice, 42)     // appending elements to a Slice
+	tSlice = tSlice[:len(tSlice)-1] // reslice the Slice after getting last item ==> emulate pop()
+	lengthOfSlice := len(tSlice)
+
+	tMap["new key"] = 42    // insert new keys
+	delete(tMap, "new key") // remove keys from Map
+
+	// Find elements in a Slice by implementing a for loop
+	// Find keys in a Map by implementing a for loop
+	// Find values in a Map by implementing a for loop
+
+	////////////////////////////////////////////////////////////////////////////
+	// Regex usage
+	////////////////////////////////////////////////////////////////////////////
+
+	re := regexp.MustCompile(`[a-z]+`)                             // compile regex expressions before
+	_ = re.FindAllString("ab3 c22 dd5", -1)                        // ["ab", "c", "dd"]
+	_ = regexp.MustCompile(`\+1[0-9]{7}`).MatchString("+12345678") // true
+	_ = regexp.MustCompile(`>([a-z]+)<`).FindStringSubmatch(
+		"<123>abcd</123>")[1] // abcd
+
+	////////////////////////////////////////////////////////////////////////////
+	// You MUST use every declared variable
+	fmt.Println(tBool, tStr, tInt, tFloat, structVar, tNil, tSlice, tMap, powered,
+		modDivision, floored, ceiled, roundedStr, rounded, newInt, c, formattedString,
+		stringLengthBytes, stringLength, tPointer, firstElement, lastElement,
+		firstAndSecond, elementIndex, tSlice, lengthOfSlice)
+
+	directions := [][]int{
+		[]int{0, 1}, 
+		[]int{1, 1}, 
+		[]int{1, 0}, 
+		[]int{1, -1},
+		 []int{0, -1}, 
+		 []int{-1, -1},
+		  []int{-1, 0},
+		   []int{-1, 1}
+		}
+
+}

--- a/boilerplates/python/cheatsheet.py
+++ b/boilerplates/python/cheatsheet.py
@@ -1,0 +1,131 @@
+############################################################################
+# Language idiosyncratics
+############################################################################
+x = """
+- no strong typing - variables can be any type (at least by default)
+- Indentation matters (a lot)
+- <tabs> and <spaces> are VERY different - use only 4xSpaces
+- When <tabs> are mixed with <spaces> erros WILL occur
+- snake_case_is_recommended
+"""
+
+############################################################################
+# Types
+############################################################################
+t_bool = True
+t_str = "abc"
+t_int = 42
+t_float = 1234.56  # or 1.23456e3
+# t_struct # python does not have structs. Use classes/objects (or list/dicts)
+# pointers: objects and lists are always passed as pointers
+t_null = None
+
+t_list = [1, "2", True]  # there are no arrays. Elements can be anything
+t_dict = {  # newline for readability
+    "key": "value",
+    42: True,
+}  # hashmaps (key: value). values can be anything. keys must be hashable
+
+
+############################################################################
+# Maths & Basics
+############################################################################
+import math
+
+t_int += 1  # Increment by one. there is no i++ syntax
+powered = 2 ** 8  # 256
+mod_division = 13 % 5  # 3
+floored = 8 // 3  # Like floor: 2 (2.666...)
+floored = math.floor(42.8)  # 42
+ceiled = math.ceil(41.2)  # 42
+rounded = round(2.255, 2)  # 2.26
+
+
+############################################################################
+# Functions (with indentation only, no curly braces {} )
+############################################################################
+def f_function(arg1, arg2, arg3="Default value"):
+    return (arg3, arg2, arg1)
+
+
+all_args = f_function(2, True)  # all_args = (arg3, arg2, arg1)
+arg3, arg2, arg1 = f_function(2, True, "hello?")
+f_function(arg1=1, arg2=True, arg3="hello?")
+
+
+############################################################################
+# String manipulation
+############################################################################
+c = "concatenate" + " a number: " + str(10)
+formatted_string = f"interpolate variables like {c} or {t_int+10}"
+formatted_string2 = "var {}, 001 {:03d}, 2.89 {:.2f}".format("var", 1, 2.8888)
+all_lowercase = c.lower()
+all_uppercase = c.upper()
+trimmed_string = "  no spaces before or after   \n".strip()
+split_list = "split, a, string".split(", ")
+join_list = ", ".join(split_list)  # elements MUST be strings
+length_of_string = len("abç")  # 3
+replaced_string = t_str.replace("bc", "eiou")  # "abc" -> "aeiou"
+
+
+############################################################################
+# Conditionals
+############################################################################
+if True:
+    print("always true")
+elif ("condition 1" or 10 or ["a"]) and ("" or False or None or 0 or []):
+    print("Left conditions are true. Right conditions are False")
+elif t_null is not None and t_int == 42 and t_str == abc and 1 in t_list:
+    print("operators: ==, !=, >, >=, <, <=")
+else:
+    print("text without newline", end="")
+    print()  # empty line (just \n)
+
+
+############################################################################
+# Loops (break/continue apply) (python does not have classic loops)
+############################################################################
+while True:
+    print("Infinite loops are like this (until break or return)")
+    break
+
+for i in range(0, 5):
+    print(f"last printed digit is 4: {i}")
+
+for char in t_str:
+    print(f"iterate all characters from a string: {char}")
+
+for element in t_list:
+    print(f"iterate all elements from a list: {element}")
+
+for key, value in t_dict.items():
+    print(f"iterate all elements from a dict: {key}:{value}")
+
+
+############################################################################
+# Lists/Dicts manipulation
+############################################################################
+first_element = t_list[0]
+last_element = t_list[-1]  # negative index counts from the end
+first_and_second = t_list[0:2]  # sub-list syntax: from:to(exclusive)
+element_index = t_list.index("2")  # Exception if not found
+
+t_list.append("new element to the end of the list")
+popped_string = t_list.pop()  # "remove and get last element"
+length_of_list = len([0, 1, 2, 3, 4, 5, 6, 7, 8, 9])  # 10
+
+t_dict["new key"] = "new value"  # insert new keys
+remove_a_key = t_dict.pop("new key")
+
+is_true = "2" in t_list  # check if element exists in list
+is_false = "value" in t_dict  # this checks keys only
+is_true = "value" in t_dict.values()  # this checks keys only
+
+
+############################################################################
+# Regex usage
+############################################################################
+import re
+match_list = re.findall("[a-z]+", "ab3 c22 dd5")  # ['ab', 'c', 'dd']
+is_true = bool(re.search("\+1[0-9]{7}", "+12345678"))
+group_match = re.search(">([a-z]+)<", "<123>abcd</123>").group(1)


### PR DESCRIPTION
This proposal intends to include a small cheatsheet per language.
This will help everyone to write code despite the language.

The `cheatsheet.pseudo` is a guideline for writing cheatsheets for every language.

This PR includes cheatsheets for:
- Go
- Python

note: cheatsheets will not be commited outside boilerplates 